### PR TITLE
get_idle_instances return list of instance_id, so the grow_worker_by_one

### DIFF
--- a/manage-app/flaskr/aws/aws.py
+++ b/manage-app/flaskr/aws/aws.py
@@ -137,7 +137,7 @@ class AwsClient:
         """
         idle_instances = self.get_idle_instances()
         if idle_instances:
-            first_idle_instance = idle_instances[0]['Id']
+            first_idle_instance = idle_instances[0]
             response = self.elb.register_targets(
                 TargetGroupArn = self.TargetGroupArn,
                 Targets=[


### PR DESCRIPTION
should not use the key 'Id'